### PR TITLE
Fix: Version in install instructions corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Install rust language and run
 $ sudo apt update
 $ sudo apt install -y cargo libssl-dev libzmq3-dev pkg-config g++ cmake libgtk-3-dev libsqlite3-dev
 $ rustup default nightly
-$ cargo install bitcoin-pro --version 0.1.0-beta.2
+$ cargo install bitcoin-pro --version 0.1.0-beta.1
 $ bitcoin-pro
 ```
 


### PR DESCRIPTION
This version can be installed via crates.io
The previous version described was not released on crates.io