### PR TITLE
Add macos installation method, fix macos window problem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Be warned that adding unstable packages to your system can, well, make your syst
 # Install rust language
 $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-# Install the dependency package gtk+3 through homebrew
-$ brew install gtk+3 git
+# Install the dependency package gtk+3 & adwaita-icon-theme through homebrew
+$ brew install gtk+3 git adwaita-icon-theme
 
 # clone bitcoin-pro
 $ git clone https://github.com/pandoracore/bitcoin-pro.git

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ but previous versions should work fine) and (probably) Windows 10.
 
 NB: This is an ultra-early alpha version; use it at your own risk!
 
-Demo video: [Bitcoin Pro demo. Part I](https://youtu.be/RkUHmgMUVrI), [Bitcoin Pro demo. Part II](https://youtu.be/iWJBikv0mbI)
+Demo video: [Bitcoin Pro demo. Part I](https://youtu.be/RkUHmgMUVrI), 
+[Bitcoin Pro demo. Part II](https://youtu.be/iWJBikv0mbI)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ form of PSBTs (partially-signed bitcoin transactions) and for their completion
 must be signed and published to bitcoin network outside of the application.
 
 Bitcoin Pro is written exclusively in Rust language with GTK framework and 
-natively compiles/works on Linux, MacOS (GTK is not supported on Big Sur yet; 
+natively compiles/works on Linux ~~, MacOS (GTK is not supported on Big Sur yet~~; 
 but previous versions should work fine) and (probably) Windows 10.
 
 NB: This is an ultra-early alpha version; use it at your own risk!
+
+Demo video: [Bitcoin Pro demo. Part I](https://youtu.be/RkUHmgMUVrI), [Bitcoin Pro demo. Part II](https://youtu.be/iWJBikv0mbI)
 
 ## Features
 
@@ -79,6 +81,25 @@ Then you can install testing version of the packages:
 ...and resume the installation process.
 
 Be warned that adding unstable packages to your system can, well, make your system less stable, so be careful with that. 
+
+### Installation on MacOS Big Sur
+```
+# Install rust language
+$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Install the dependency package gtk+3 through homebrew
+$ brew install gtk+3 git
+
+# clone bitcoin-pro
+$ git clone https://github.com/pandoracore/bitcoin-pro.git
+
+# Enter bitcoin-pro folder
+$ cd bitcoin-pro
+
+$ rustup default nightly
+$ cargo install bitcoin-pro
+$ bitcoin-pro
+```
 
 ## Using
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ form of PSBTs (partially-signed bitcoin transactions) and for their completion
 must be signed and published to bitcoin network outside of the application.
 
 Bitcoin Pro is written exclusively in Rust language with GTK framework and 
-natively compiles/works on Linux ~~, MacOS (GTK is not supported on Big Sur yet~~; 
+natively compiles/works on Linux, MacOS (~~GTK is not supported on Big Sur yet~~; 
 but previous versions should work fine) and (probably) Windows 10.
 
 NB: This is an ultra-early alpha version; use it at your own risk!


### PR DESCRIPTION
* add the installation process of Bitcoin Pro on macOS
* Add Demo video link
ps. Because I have successfully installed `brew install gtk+3`, I deleted the first paragraph related to macOS.
At the same time, fix the problem that the icon in the window is invalid.

Demo:
![截圖 2021-03-29 下午1 22 14](https://user-images.githubusercontent.com/54278075/112790380-cda91500-9091-11eb-8542-cc008ca001cd.png)
![截圖 2021-03-29 下午1 22 16](https://user-images.githubusercontent.com/54278075/112790388-d0a40580-9091-11eb-8dd6-b0da46e9c268.png)
